### PR TITLE
fix: download in case when url file was dropped or any exist() error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "quicksync"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicksync"
-version = "0.1.12"
+version = "0.1.14"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Fixes some edge-cases which produces bugs, like this one:
![image](https://github.com/user-attachments/assets/2abca935-2295-4767-8614-771c9c8a0e92)
