### PR TITLE
Cleanups in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,7 @@ jobs:
         with:
           components: clippy
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Annotate commit with clippy warnings
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --workspace
+      - uses: clechasseur/rs-clippy-check@v3
 
   build:
     name: Build library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@1.80
@@ -22,7 +22,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.80
         with:
           components: rustfmt
@@ -32,7 +32,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
@@ -48,6 +48,7 @@ jobs:
     name: Build library
     runs-on: ${{ matrix.os }}
     needs:
+      - check
       - fmt
       - clippy
     strategy:
@@ -66,10 +67,10 @@ jobs:
           - os: macos-13
             artifact-name: macos
 
-          - os: windows-2019
+          - os: windows-2022
             artifact-name: windows
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.80
       - uses: Swatinem/rust-cache@v2
         with:
@@ -97,7 +98,7 @@ jobs:
         with:
           name: quicksync-${{ matrix.artifact-name }}
           path: |
-            target/release/quicksync${{ matrix.os == 'windows-2019' && '.exe' || '' }}
+            target/release/quicksync${{ matrix.os == 'windows-2022' && '.exe' || '' }}
           if-no-files-found: error
 
   coverage:
@@ -122,7 +123,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@1.74.1
+      - uses: dtolnay/rust-toolchain@1.80
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-features
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.74.1
+      - uses: dtolnay/rust-toolchain@1.80
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -70,7 +70,7 @@ jobs:
             artifact-name: windows
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.74.1
+      - uses: dtolnay/rust-toolchain@1.80
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ join( matrix.os, '-' ) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: dtolnay/rust-toolchain@1.80
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-features
@@ -86,8 +84,6 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@1.80
       - run: cargo install cargo-tarpaulin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,6 @@ jobs:
         with:
           key: ${{ join( matrix.os, '-' ) }}
 
-      - name: Install SQLite3 (Linux Arm64)
-        if: matrix.artifact-name == 'linux-arm64'
-        run: sudo apt-get install libsqlite3-dev
-
-      - name: Install SQLite3 (Windows)
-        if: matrix.artifact-name == 'windows'
-        run: |
-          choco install -y wget
-          cd C:\
-          mkdir lib
-          cd lib
-          wget https://github.com/buggins/ddbc/raw/master/libs/win64/sqlite3.lib
-          echo "LIB=C:\lib" >> $env:GITHUB_ENV
-
       - name: Build
         run: cargo build --release
 


### PR DESCRIPTION
Changes:
- updated Rust to 1.80
- removed installation of sqlite. It is already bundled with the `rusqlite` crate (feature `bundled` is used)
- updated the clippy action (the previous is archived)
- updated the windows runner to 2022