### PR TITLE
reduce unpacking prints spam

### DIFF
--- a/src/reader_with_bytes.rs
+++ b/src/reader_with_bytes.rs
@@ -1,11 +1,11 @@
 use std::io::{self, Read};
 
-const MB: u64 = 1024 * 1024;
+const MB: usize = 1024 * 1024;
 
 pub struct ReaderWithBytes<R: Read> {
   reader: R,
-  bytes_read: u64,
-  last_reported: u64,
+  bytes_read: usize,
+  last_reported: usize,
 }
 
 impl<R: Read> ReaderWithBytes<R> {
@@ -21,9 +21,9 @@ impl<R: Read> ReaderWithBytes<R> {
 impl<R: Read> Read for ReaderWithBytes<R> {
   fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
     let bytes_read = self.reader.read(buf)?;
-    self.bytes_read += bytes_read as u64;
+    self.bytes_read += bytes_read;
 
-    if self.bytes_read / MB > self.last_reported / MB {
+    if self.bytes_read > self.last_reported + 1000 * MB {
       println!("Unpacking... {} MB extracted", self.bytes_read / MB);
       self.last_reported = self.bytes_read;
     }


### PR DESCRIPTION
Currently, it prints every 1MiB, which generates an endless wall of text (around 157000 lines for the current size of DB). This PR changes the print interval to every 1000 MiB.